### PR TITLE
Tweak description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -49,9 +49,9 @@
 		<meta property="se:subject">Spirituality</meta>
 		<dc:description id="description">Prose poems of offering translated by the author from the original Bengali.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
-			&lt;p&gt;Widely regarded as one of the most important figures in Indian (and more specifically Bengali) literary history, &lt;a href="https://standardebooks.org/ebooks/rabindranath-tagore"&gt;Rabindranath Tagore&lt;/a&gt; was the first Indian (and indeed the first person outside Europe) to win the Nobel Prize in Literature, largely in recognition of his “spiritual offering of songs,” &lt;i&gt;Gitanjali&lt;/i&gt;.&lt;/p&gt;
+			&lt;p&gt;Widely regarded as one of the most important figures in Indian (and more specifically Bengali) literary history, &lt;a href="https://standardebooks.org/ebooks/rabindranath-tagore"&gt;Rabindranath Tagore&lt;/a&gt; was the first Indian—indeed, the first person outside Europe—to win the Nobel Prize in Literature, largely in recognition of his “spiritual offering of songs,” &lt;i&gt;Gitanjali&lt;/i&gt;.&lt;/p&gt;
 			&lt;p&gt;Tagore himself translated the poems from the original Bengali, taking many liberties in the process. His English translation is rightly recognized as a work distinct from the Bengali original, consisting of major revisions, many elisions, and many poems originally published in other collections.&lt;/p&gt;
-			&lt;p&gt;Tagore’s lyrical simplicity, vivid imagery, and themes of nature, spirituality, death, and transcendence, combine to produce a truly unique, powerfully moving work of thoughtful beauty. For many who read it, Tagore’s words in Song XCVI ring true: “What I have seen is unsurpassable. I have tasted of the hidden honey of this lotus that expands on the ocean of light, and thus I am blessed.”&lt;/p&gt;
+			&lt;p&gt;Tagore’s lyrical simplicity, vivid imagery, and themes of nature, spirituality, death, and transcendence combine to produce a truly unique, powerfully moving work of thoughtful beauty. For many who read it, Tagore’s words in Song XCVI ring true: “What I have seen is unsurpassable. I have tasted of the hidden honey of this lotus that expands on the ocean of light, and thus I am blessed.”&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/7164</dc:source>


### PR DESCRIPTION
I think dashes set this off better, in particular since there’s another instance of ‘and’ within parentheses in the same sentence (and it doesn’t seem an intentional aesthetic).