### PR TITLE
Fix typo

### DIFF
--- a/src/epub/text/gitanjali.xhtml
+++ b/src/epub/text/gitanjali.xhtml
@@ -711,7 +711,7 @@
 			<h2 epub:type="ordinal z3998:roman">CI</h2>
 			<p>Ever in my life have I sought thee with my songs. It was they who led me from door to door, and with them have I felt about me, searching and touching my world.</p>
 			<p>It was my songs that taught me all the lessons I ever learnt; they showed me secret paths, they brought before my sight many a star on the horizon of my heart.</p>
-			<p>They guided me all the day long to the mysteries of the country of pleasure and pain, and, at last, to what palace gate have the brought me in the evening at the end of my journey?</p>
+			<p>They guided me all the day long to the mysteries of the country of pleasure and pain, and, at last, to what palace gate have they brought me in the evening at the end of my journey?</p>
 		</article>
 		<article id="song-102" epub:type="z3998:poem">
 			<h2 epub:type="ordinal z3998:roman">CII</h2>


### PR DESCRIPTION
Fix typo in song-101: `the` should be `they`. This typo is present in the Project Gutenberg transcription as well (will email them an errata report).

See [the original scans](https://catalog.hathitrust.org/Record/007133071) for reference.